### PR TITLE
Fix Android 9 crash from launcher radial gradient radius

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,3 +36,10 @@ jobs:
 
       - name: Verify Android build
         run: ./gradlew :app:assemble
+
+      - name: Upload APKs
+        uses: actions/upload-artifact@v7
+        with:
+          name: apks
+          path: app/build/outputs/apk/**/*.apk
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,14 @@ jobs:
       - name: Verify Android build
         run: ./gradlew :app:assemble
 
-      - name: Upload APKs
+      - name: Upload api29 debug APKs
         uses: actions/upload-artifact@v7
         with:
-          name: apks
-          path: app/build/outputs/apk/**/*.apk
+          name: api29-debug-apks
+          path: app/build/outputs/apk/api29/debug/*.apk
 
+      - name: Upload api29 release APKs
+        uses: actions/upload-artifact@v7
+        with:
+          name: api29-release-apks
+          path: app/build/outputs/apk/api29/release/*.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,15 +36,3 @@ jobs:
 
       - name: Verify Android build
         run: ./gradlew :app:assemble
-
-      - name: Upload api29 debug APKs
-        uses: actions/upload-artifact@v7
-        with:
-          name: api29-debug-apks
-          path: app/build/outputs/apk/api29/debug/*.apk
-
-      - name: Upload api29 release APKs
-        uses: actions/upload-artifact@v7
-        with:
-          name: api29-release-apks
-          path: app/build/outputs/apk/api29/release/*.apk

--- a/app/src/main/res/drawable/bg_tv_launcher.xml
+++ b/app/src/main/res/drawable/bg_tv_launcher.xml
@@ -17,7 +17,7 @@
                 android:type="radial"
                 android:centerX="0.15"
                 android:centerY="0.18"
-                android:gradientRadius="780"
+                android:gradientRadius="780dp"
                 android:startColor="?attr/mpvWindowGlowStart"
                 android:endColor="?attr/mpvWindowGlowEnd" />
         </shape>
@@ -29,7 +29,7 @@
                 android:type="radial"
                 android:centerX="0.84"
                 android:centerY="0.72"
-                android:gradientRadius="860"
+                android:gradientRadius="860dp"
                 android:startColor="?attr/mpvWindowGlowAltStart"
                 android:endColor="?attr/mpvWindowGlowAltEnd" />
         </shape>


### PR DESCRIPTION
This fixes a startup crash on Android 9 TV devices caused by bg_tv_launcher.xml using unitless android:gradientRadius values in radial gradients.

On affected devices, launching the app fails before the home screen is drawn:

Resources$NotFoundException: Drawable app.mpvnova.player:drawable/bg_tv_launcher
Caused by: XmlPullParserException: <gradient> tag requires 'gradientRadius' attribute with radial type

Android 9’s drawable parser does not accept the unitless values, so it treats the required radius as missing. The fix changes the radial gradient radii from raw numbers to explicit dp dimensions.